### PR TITLE
reuse delete all webhooks workflow to automatically delete orphaned w…

### DIFF
--- a/.github/workflows/cron_weekend.yaml
+++ b/.github/workflows/cron_weekend.yaml
@@ -1,0 +1,11 @@
+name: Weekend Cleanup
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * SAT'
+
+jobs:
+  call-delete-all-webhooks:
+    uses: hashicorp/terraform-random-1/.github/workflows/delete_all_webhooks.yaml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
…ebhooks created by provider-tfe tests.

This GitHub action workflow uses a cron job from [hashicorp/terraform-random-1 repo](https://github.com/terraform-providers/terraform-random-1/blob/main/.github/workflows/delete_all_webhooks.yaml). If you see a 404 for the repo, it is because this repository has been archived and new access is not be provided. Though I don't think it will be deleted anytime soon.

In case you cannot access the repo, here is the source code that we are using for the workflow:

```
name: Delete All Webhooks
on:
  workflow_dispatch:
  workflow_call:
    secrets:
      GH_TOKEN:
        required: true
  schedule:
    - cron: '0 0 * * SAT'

jobs:
  fetchWebhooks:
    runs-on: ubuntu-latest
    outputs:
      hook_ids: ${{ steps.format.outputs.hook_ids }}

    steps:
      - uses: octokit/request-action@v2.x
        id: request
        with:
          route: GET /repos/${{ github.repository }}/hooks
        env:
          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
      - id: format
        run: |
          echo "hook_ids=$(jq -n '${{ steps.request.outputs.data }}' | jq -rc '[.[] .id]')\n" >> $GITHUB_OUTPUT
      - run: |
          echo 'Deleting these webhook ids: ${{ steps.format.outputs.hook_ids }}'

  cleanWebhooks:
    runs-on: ubuntu-latest
    needs: [ fetchWebhooks ]
    if: fromJSON(needs.fetchWebhooks.outputs.hook_ids)[0] != null
    strategy:
      matrix:
        value: ${{fromJSON(needs.fetchWebhooks.outputs.hook_ids)}}
    steps:
      - uses: octokit/request-action@v2.x
        id: delete_webhook
        with:
          route: DELETE /repos/${{ github.repository }}/hooks/${{ matrix.value }}
        env:
          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
```

The reasons why we need this workflow are documented in this Jira ticket description:

https://hashicorp.atlassian.net/browse/TF-18315